### PR TITLE
Create GH Actions workflow for pre-merge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,42 @@
+name: CI Checks
+
+on:
+
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+
+jobs:
+
+  run-tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PYTHON_VERSION: ["3.10", "3.11"]
+    steps:
+
+      - name: Install required Debian packages
+        run: |
+          echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
+          sudo apt install --yes ttf-mscorefonts-installer
+          sudo fc-cache -f
+
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.PYTHON_VERSION }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.PYTHON_VERSION }}
+          cache: "pip"
+
+      - name: Install Python requirements
+        run: pip install -r requirements.txt
+
+      - name: Run pytest
+        run: |
+          pytest src/tests/


### PR DESCRIPTION
This GitHub Actions workflow triggers pytest in `src/tests/`. It triggers the execution on each PR and on every push to the main branch. The tests run on Ubuntu with Python `3.10` and `3.11`.

To ensure that everything gets tested, we should add this workflow as a requirement for every PR to pass.

Currently, the workflow installs the fonts on the testing system. As this requires some execution time, the installation should be cached. Alternatively, #20 wants the requirement of a specific font to be removed.