### PR TITLE
Add pytest markers to focus only on unit tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,4 +59,4 @@ jobs:
         if (Test-Path requirements.txt) { pip install -r requirements.txt }
     - name: Test with pytest
       run: |
-        pytest src/tests/
+        pytest -m 'unit'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,9 @@ exclude = [
 [tool.setuptools.dynamic]
 version = { attr = "roadmapper.version.__version__" }
 readme = { file = ["README.md"] }
+
+[tool.pytest.ini_options]
+addopts ="-v"
+markers = [
+    "unit: Unit tests which are not dependent on environment",
+]

--- a/src/tests/roadmap_draw_test.py
+++ b/src/tests/roadmap_draw_test.py
@@ -7,34 +7,34 @@ import pytest
 from src.roadmapper.roadmap import Roadmap
 
 
-def test_draw_roadmap_with_minimal_required_features():
-    roadmap: Roadmap = Roadmap()
-    roadmap.set_timeline(start="2023-01-01")
-    roadmap.set_title("Test Title")
+@pytest.mark.unit
+class TestRoadmapDraw:
+    def test_draw_roadmap_with_minimal_required_features(self):
+        roadmap: Roadmap = Roadmap()
+        roadmap.set_timeline(start="2023-01-01")
+        roadmap.set_title("Test Title")
 
-    roadmap.draw()
-
-    filename_with_ts = str(calendar.timegm(time.gmtime())) + ".png"
-    roadmap.save(filename_with_ts)
-
-    assert os.path.exists(filename_with_ts)
-    os.remove(filename_with_ts)
-
-
-def test_draw_roadmap_requires_timeline():
-    roadmap: Roadmap = Roadmap()
-    roadmap.set_title("Test Title")
-
-    with pytest.raises(ValueError) as e:
         roadmap.draw()
 
-    assert "timeline" in str(e.value).lower()
+        filename_with_ts = str(calendar.timegm(time.gmtime())) + ".png"
+        roadmap.save(filename_with_ts)
 
+        assert os.path.exists(filename_with_ts)
+        os.remove(filename_with_ts)
 
-def test_draw_roadmap_requires_title():
-    roadmap: Roadmap = Roadmap()
+    def test_draw_roadmap_requires_timeline(self):
+        roadmap: Roadmap = Roadmap()
+        roadmap.set_title("Test Title")
 
-    with pytest.raises(ValueError) as e:
-        roadmap.draw()
+        with pytest.raises(ValueError) as e:
+            roadmap.draw()
 
-    assert "title" in str(e.value).lower()
+        assert "timeline" in str(e.value).lower()
+
+    def test_draw_roadmap_requires_title(self):
+        roadmap: Roadmap = Roadmap()
+
+        with pytest.raises(ValueError) as e:
+            roadmap.draw()
+
+        assert "title" in str(e.value).lower()


### PR DESCRIPTION
In this PR, I add some config for PyTest in the `pyproject.toml`. Namely, I set the test output to verbose to show some more details when running the tests. Additionally, I introduce `markers` as they allow us to run specific test groups. With this feature, we can run tests specific to certain platforms (which will be needed by my next PR). 

If we now run `pytest -m 'unit'`, we only trigger the tests which have the marker `unit`. For marking several tests in a file, these tests should be grouped together in a class. Currently, I only marked one test with `unit` because the other tests are quite messy and do not really _test_ specifics.