### PR TITLE
Enable OS agnostic tests

### DIFF
--- a/src/tests/compare_generated_roadmaps_test.py
+++ b/src/tests/compare_generated_roadmaps_test.py
@@ -19,24 +19,6 @@ suffix_for_diffs = "Diff"
 file_ending_for_diffs = file_ending_for_examples
 
 
-def get_example_file_path_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> str:
-    return dir_for_examples \
-        + "/" \
-        + roadmap_generator.get_roadmap_name_for(roadmap_class, operating_system) \
-        + suffix_for_examples \
-        + file_ending_for_examples
-
-
-def get_example_roadmap_image_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> Image:
-    path_of_example = get_example_file_path_for(roadmap_class, operating_system)
-    return Image.open(path_of_example).convert("RGB")
-
-
-def get_generated_roadmap_image_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> Image:
-    path_of_generated = roadmap_generator.get_generated_file_path_for(roadmap_class, operating_system)
-    return Image.open(path_of_generated).convert("RGB")
-
-
 def ensure_presence_of_file_directory(directory):
     if directory and not os.path.exists(directory):
         os.makedirs(directory)
@@ -58,12 +40,30 @@ def handle_difference(diff, roadmap_class: Type[RoadmapABC], operating_system: s
     diff.save(diff_file_path)
 
 
+def get_generated_roadmap_image_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> Image:
+    path_of_generated = roadmap_generator.get_generated_file_path_for(roadmap_class, operating_system)
+    return Image.open(path_of_generated).convert("RGB")
+
+
+def get_example_file_path_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> str:
+    return dir_for_examples \
+        + "/" \
+        + roadmap_generator.get_roadmap_name_for(roadmap_class, operating_system) \
+        + suffix_for_examples \
+        + file_ending_for_examples
+
+
+def get_example_roadmap_image_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> Image:
+    path_of_example = get_example_file_path_for(roadmap_class, operating_system)
+    return Image.open(path_of_example).convert("RGB")
+
+
 @pytest.mark.ubuntu
 class TestCompareGeneratedRoadmaps:
 
     def test_colour_theme_extensive(self, operating_system_ubuntu):
         roadmap_class_to_test = ColourThemeExtensive
-        roadmap_generator.generate_and_save_roadmap_in(roadmap_class_to_test, operating_system_ubuntu, dir_for_generated)
+        roadmap_generator.generate_and_save_roadmap(roadmap_class_to_test, operating_system_ubuntu, dir_for_generated)
         example_roadmap = get_example_roadmap_image_for(roadmap_class_to_test, operating_system_ubuntu)
         generated_roadmap = get_generated_roadmap_image_for(roadmap_class_to_test, operating_system_ubuntu)
 

--- a/src/tests/compare_generated_roadmaps_test.py
+++ b/src/tests/compare_generated_roadmaps_test.py
@@ -19,21 +19,21 @@ suffix_for_diffs = "Diff"
 file_ending_for_diffs = file_ending_for_examples
 
 
-def get_example_file_path(roadmap_class: Type[RoadmapABC]) -> str:
+def get_example_file_path_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> str:
     return dir_for_examples \
         + "/" \
-        + roadmap_generator.get_roadmap_name_for(roadmap_class) \
+        + roadmap_generator.get_roadmap_name_for(roadmap_class, operating_system) \
         + suffix_for_examples \
         + file_ending_for_examples
 
 
-def get_example_roadmap_image(roadmap_class: Type[RoadmapABC]) -> Image:
-    path_of_example = get_example_file_path(roadmap_class)
+def get_example_roadmap_image_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> Image:
+    path_of_example = get_example_file_path_for(roadmap_class, operating_system)
     return Image.open(path_of_example).convert("RGB")
 
 
-def get_generated_roadmap_image(roadmap_class: Type[RoadmapABC]) -> Image:
-    path_of_generated = roadmap_generator.get_generated_file_path_for(roadmap_class)
+def get_generated_roadmap_image_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> Image:
+    path_of_generated = roadmap_generator.get_generated_file_path_for(roadmap_class, operating_system)
     return Image.open(path_of_generated).convert("RGB")
 
 
@@ -42,34 +42,35 @@ def ensure_presence_of_file_directory(directory):
         os.makedirs(directory)
 
 
-def get_diff_file_path(roadmap_class: Type[RoadmapABC]) -> str:
+def get_diff_file_path_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> str:
     ensure_presence_of_file_directory(dir_for_diffs)
     return dir_for_diffs \
         + "/" \
-        + roadmap_generator.get_roadmap_name_for(roadmap_class) \
+        + roadmap_generator.get_roadmap_name_for(roadmap_class, operating_system) \
         + suffix_for_diffs \
         + file_ending_for_diffs
 
 
-def handle_difference(diff, roadmap_class: Type[RoadmapABC]):
+def handle_difference(diff, roadmap_class: Type[RoadmapABC], operating_system: str):
     print("The generated roadmap looks different from the example.")
     print("Run the test locally to see the generated difference.")
-    diff_file_path = get_diff_file_path(roadmap_class)
+    diff_file_path = get_diff_file_path_for(roadmap_class, operating_system)
     diff.save(diff_file_path)
 
 
 @pytest.mark.ubuntu
 class TestCompareGeneratedRoadmaps:
-    def test_colour_theme_extensive(self):
+
+    def test_colour_theme_extensive(self, operating_system_ubuntu):
         roadmap_class_to_test = ColourThemeExtensive
-        roadmap_generator.generate_and_save_roadmap_in(roadmap_class_to_test, dir_for_generated)
-        example_roadmap = get_example_roadmap_image(roadmap_class_to_test)
-        generated_roadmap = get_generated_roadmap_image(roadmap_class_to_test)
+        roadmap_generator.generate_and_save_roadmap_in(roadmap_class_to_test, operating_system_ubuntu, dir_for_generated)
+        example_roadmap = get_example_roadmap_image_for(roadmap_class_to_test, operating_system_ubuntu)
+        generated_roadmap = get_generated_roadmap_image_for(roadmap_class_to_test, operating_system_ubuntu)
 
         test_diff = ImageChops.difference(example_roadmap, generated_roadmap)
 
         if test_diff.getbbox():
-            handle_difference(test_diff, roadmap_class_to_test)
+            handle_difference(test_diff, roadmap_class_to_test, operating_system_ubuntu)
             assert False
         else:
             assert True

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -3,9 +3,16 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def change_test_dir(request, monkeypatch):
+    """
+    This fixture ensures that generated roadmaps end up in correct path,
+    no matter from which path tests are executed.
+    """
     monkeypatch.chdir(request.fspath.dirname)
 
 
 @pytest.fixture(scope="session")
 def operating_system_ubuntu():
+    """
+    This fixture can be used as test argument to provide string of used OS `Ubuntu`.
+    """
     return "Ubuntu"

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -4,3 +4,8 @@ import pytest
 @pytest.fixture(autouse=True)
 def change_test_dir(request, monkeypatch):
     monkeypatch.chdir(request.fspath.dirname)
+
+
+@pytest.fixture(scope="session")
+def operating_system_ubuntu():
+    return "Ubuntu"

--- a/src/tests/roadmap_generators/roadmap_generator.py
+++ b/src/tests/roadmap_generators/roadmap_generator.py
@@ -9,10 +9,6 @@ file_directory = ""
 all_roadmaps_to_generate: [RoadmapABC] = [ColourThemeExtensive]
 
 
-def get_all_roadmap_names_to_generate_for(operating_system: str) -> [str]:
-    return [get_roadmap_name_for(cls, operating_system) for cls in all_roadmaps_to_generate]
-
-
 def append_trailing_slash_if_necessary(directory) -> str:
     if directory and not directory.endswith(os.path.sep):
         return directory + os.path.sep
@@ -38,7 +34,7 @@ def get_generated_file_path_for(roadmap_class: Type[RoadmapABC], operating_syste
     return file_directory + get_roadmap_name_for(roadmap_class, operating_system) + file_ending
 
 
-def generate_and_save_roadmap_in(roadmap_class: Type[RoadmapABC], operating_system: str, target_directory: str = ""):
+def generate_and_save_roadmap(roadmap_class: Type[RoadmapABC], operating_system: str, target_directory: str = ""):
     set_file_directory(target_directory)
     file_path = get_generated_file_path_for(roadmap_class, operating_system)
     generating_object = roadmap_class()
@@ -48,9 +44,7 @@ def generate_and_save_roadmap_in(roadmap_class: Type[RoadmapABC], operating_syst
 def generate_and_save_all_roadmaps_in(target_directory: str = "", operating_system: str = "Ubuntu"):
     set_file_directory(target_directory)
     for generating_class in all_roadmaps_to_generate:
-        file_path = get_generated_file_path_for(generating_class, operating_system)
-        generating_object = generating_class()
-        generating_object.generate_and_save_as(file_path)
+        generate_and_save_roadmap(generating_class, operating_system, target_directory)
 
 
 if __name__ == "__main__":

--- a/src/tests/roadmap_generators/roadmap_generator.py
+++ b/src/tests/roadmap_generators/roadmap_generator.py
@@ -3,15 +3,14 @@ from typing import Type
 
 from src.tests.roadmap_generators.colour_theme_extensive import ColourThemeExtensive
 from src.tests.roadmap_generators.roadmap_abc import RoadmapABC
-import pytest
 
 file_ending = ".png"
 file_directory = ""
 all_roadmaps_to_generate: [RoadmapABC] = [ColourThemeExtensive]
 
 
-def get_all_roadmap_names_to_generate() -> [str]:
-    return [get_roadmap_name_for(cls) for cls in all_roadmaps_to_generate]
+def get_all_roadmap_names_to_generate_for(operating_system: str) -> [str]:
+    return [get_roadmap_name_for(cls, operating_system) for cls in all_roadmaps_to_generate]
 
 
 def append_trailing_slash_if_necessary(directory) -> str:
@@ -30,33 +29,29 @@ def ensure_presence_of_file_directory(directory):
         os.makedirs(directory)
 
 
-def get_roadmap_name_for(roadmap_class: Type[RoadmapABC]) -> str:
-    return roadmap_class.__name__ + "Ubuntu"  # TODO: Make OS agnostic
+def get_roadmap_name_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> str:
+    return roadmap_class.__name__ + operating_system
 
 
-def get_generated_file_path_for(roadmap_class: Type[RoadmapABC]) -> str:
+def get_generated_file_path_for(roadmap_class: Type[RoadmapABC], operating_system: str) -> str:
     ensure_presence_of_file_directory(file_directory)
-    return file_directory + get_roadmap_name_for(roadmap_class) + file_ending
+    return file_directory + get_roadmap_name_for(roadmap_class, operating_system) + file_ending
 
 
-def generate_and_save_roadmap_in(
-    roadmap_class: Type[RoadmapABC], target_directory: str = ""
-):
+def generate_and_save_roadmap_in(roadmap_class: Type[RoadmapABC], operating_system: str, target_directory: str = ""):
     set_file_directory(target_directory)
-    file_path = get_generated_file_path_for(roadmap_class)
+    file_path = get_generated_file_path_for(roadmap_class, operating_system)
     generating_object = roadmap_class()
     generating_object.generate_and_save_as(file_path)
 
 
-def generate_and_save_all_roadmaps_in(target_directory: str = ""):
+def generate_and_save_all_roadmaps_in(target_directory: str = "", operating_system: str = "Ubuntu"):
     set_file_directory(target_directory)
     for generating_class in all_roadmaps_to_generate:
-        file_path = get_generated_file_path_for(generating_class)
+        file_path = get_generated_file_path_for(generating_class, operating_system)
         generating_object = generating_class()
         generating_object.generate_and_save_as(file_path)
 
 
 if __name__ == "__main__":
     generate_and_save_all_roadmaps_in()
-
-


### PR DESCRIPTION
With this PR, I introduce another variable in the OS-specific tests to easily allow recreating these tests for other OSs. Currently, the OS var is only available as `Ubuntu` and can be retrieved via the fixture `operating_system_ubuntu`. In the future, the value of the OS var should be tied to the used marker.

In addition, I use this PR to adapt method names and order to increase readability. This also included removing the unused method `get_all_roadmap_names_to_generate` and slimming the method `generate_and_save_all_roadmaps_in`.