### PR TITLE
Simplify dependency installation by treating all OSs same way

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,17 +49,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: "pip"
 
-    - name: Install dependencies (non-Windows)
-      if: matrix.os != 'windows-latest'
+    - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
-    - name: Install dependencies (Windows)
-      if: matrix.os == 'windows-latest'
-      run: |
-        python -m pip install --upgrade pip
-        if (Test-Path requirements.txt) { pip install -r requirements.txt }
+        pip install -r requirements.txt
 
     - name: Unit tests with pytest
       run: |


### PR DESCRIPTION
The only difference between the two ways of installing the requirements for Windows and non-Windows was the `if` statement (Bash and PowerShell). The `if` statement results in installing the requirements only if the `requirements.txt` is present. With or without the `if` statement, the CI build would fail without the `requirements.txt` not being present. Therefore, we do not require this check and can simplify the workflow file.