### PR TITLE
Checkout only specific paths to speed up workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,12 @@ jobs:
         echo "LANGUAGE=en_US" >> $GITHUB_ENV
 
     - uses: actions/checkout@v3
+      with:
+        sparse-checkout: |
+          .github
+          src
+          pyproject.toml
+          requirements.txt
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4

--- a/.github/workflows/generate_examples.yaml
+++ b/.github/workflows/generate_examples.yaml
@@ -16,6 +16,12 @@ jobs:
     steps:
 
     - uses: actions/checkout@v3
+      with:
+        sparse-checkout: |
+          .github
+          src
+          pyproject.toml
+          requirements.txt
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4


### PR DESCRIPTION
Performing a sparse-checkout results in cloning only the required paths. Directories like `images/` or the file `README.md` is not required for testing the application and do not have to be cloned.