### PR TITLE
Add missing pytest marker for tests on OS Windows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,4 +39,5 @@ markers = [
     "unit: Unit tests which are not dependent on environment",
     "ubuntu: Tests which only apply to Ubuntu environment",
     "macos: Tests which only apply to macOS environment",
+    "windows: Tests which only apply to Windows environment",
 ]


### PR DESCRIPTION
Adding this marker to the file `pyproject.toml` removes the warning about a missing marker.