### PR TITLE
Upload diffs in case of previous test failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,3 +72,12 @@ jobs:
       if: matrix.os == 'windows-latest'
       run: |
         pytest -m 'windows'
+
+    - name: Upload image diffs when tests failed
+      if: failure()
+      uses: actions/upload-artifact@v3
+      with:
+        name: diffs-of-generated-roadmaps-${{ matrix.os }}-${{ matrix.python-version }}
+        path: |
+          src/tests/diffs_of_generated_roadmaps/
+          src/tests/generated_roadmaps/

--- a/src/tests/compare_generated_roadmaps_test.py
+++ b/src/tests/compare_generated_roadmaps_test.py
@@ -36,7 +36,8 @@ def get_diff_file_path_for(roadmap_class: Type[RoadmapABC], operating_system: st
 
 def handle_difference(diff, roadmap_class: Type[RoadmapABC], operating_system: str):
     print("The generated roadmap looks different from the example.")
-    print("Run the test locally to see the generated difference.")
+    print("In case of a run with GitHub Actions, you can download the generated roadmaps and the diffs under the "
+          "artifacts of this workflow run.")
     diff_file_path = get_diff_file_path_for(roadmap_class, operating_system)
     diff.save(diff_file_path)
 
@@ -69,7 +70,6 @@ def compare_generated_roadmap_to_example(example_roadmap, generated_roadmap, ope
 
 
 def generate_and_compare_roadmap_for_specific_platform(operating_system, roadmap_class_to_test):
-
     roadmap_generator.generate_and_save_roadmap(roadmap_class_to_test, operating_system, dir_for_generated)
     generated_roadmap = get_generated_roadmap_image_for(roadmap_class_to_test, operating_system)
     example_roadmap = get_example_roadmap_image_for(roadmap_class_to_test, operating_system)


### PR DESCRIPTION
In this PR, I finally add the functionality to upload the diffs between the generated roadmaps of the tests and the example roadmaps. This gives devs the opportunity to investigate the difference between how the roadmaps should look and how their generated roadmaps look like.