### PR TITLE
Bump version of `upload-artifact`

### DIFF
--- a/.github/workflows/generate_examples.yaml
+++ b/.github/workflows/generate_examples.yaml
@@ -49,7 +49,7 @@ jobs:
         python -m src.tests.roadmap_generators.roadmap_generator --operating-system $os --target-directory examples
 
     - name: Upload generated roadmaps
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
           name: example-roadmaps-${{ matrix.os }}
           path: examples/


### PR DESCRIPTION
Discovered that we still use an action with an old node version...