### PR TITLE
chore: update checkout action to version `4`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
         echo "LANG=en_US" >> $GITHUB_ENV
         echo "LANGUAGE=en_US" >> $GITHUB_ENV
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: |
           .github

--- a/.github/workflows/generate_examples.yaml
+++ b/.github/workflows/generate_examples.yaml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: |
           .github

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         sparse-checkout: |
           .github


### PR DESCRIPTION
A few weeks back, the checkout action was updated to version `4`. As they already released the first minor upgrade to version `4.1.1`, minor issues should be removed already.