### PR TITLE
chore: upgrade to version `4` of `actions/upload-artifact`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
 
     - name: Upload image diffs when tests failed
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: diffs-of-generated-roadmaps-${{ matrix.os }}-${{ matrix.python-version }}
         path: |

--- a/.github/workflows/generate_examples.yaml
+++ b/.github/workflows/generate_examples.yaml
@@ -55,7 +55,7 @@ jobs:
         python -m src.tests.roadmap_generators.roadmap_generator --operating-system $os --target-directory examples
 
     - name: Upload generated roadmaps
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
           name: example-roadmaps-${{ matrix.os }}
           path: examples/


### PR DESCRIPTION
We can upgrade the usage of `actions/upload-artifact` to version `4`. As the action already [received some minor version releases](https://github.com/actions/upload-artifact/releases), it should be safe to upgrade. According to the [migration guide for the version upgrade](https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md), we do not require any logic changes. 

The tests will only succeed after emerging PR #81. When this PR is merged into the `main` branch, retrigger just retrigger the tests.