### PR TITLE
ci: bump `actions/setup-python` to version `5`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,7 @@ jobs:
           requirements.txt
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"

--- a/.github/workflows/generate_examples.yaml
+++ b/.github/workflows/generate_examples.yaml
@@ -24,7 +24,7 @@ jobs:
           requirements.txt
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"


### PR DESCRIPTION
[Node.js version 16 has reached EOL](https://github.com/nodejs/Release/#end-of-life-releases) and GH Actions with it are deprecated. [Version 5 of `actions/setup-python` was released in early December 2023](https://github.com/actions/setup-python/releases/tag/v5.0.0) with [using Node.js 20](https://github.com/actions/setup-python/pull/772). As the release did not introduce other significant changes, we can easily upgrade to the latest major version 5.