### PR TITLE
ci: add workflow to automatically release to PyPI and GitHub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,55 @@
+name: Release to PyPI and GitHub
+
+on:
+  push:
+    tags:
+      - 'v*'  # Push events with tags 'v*', i.e. 'v1.0.4' or 'v0.3.2'
+
+jobs:
+  deploy-with-twine:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: |
+            .github
+            src
+            pyproject.toml
+            requirements.txt
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.10
+          cache: "pip"
+
+      - name: Install dependencies (with Twine)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install twine
+
+      - name: Build dist
+        run: |
+          python -m build
+
+      - name: Test dist
+        run: |
+          python -m twine check dist/*
+
+      - name: Deploy dist
+        run: |
+          python -m twine upload dist/*
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+
+  release-on-github:
+    needs: deploy-with-twine
+    name: Trigger GitHub release workflow
+    uses: ./.github/workflows/release-on-github.yaml
+    with:
+      tag: ${{ github.ref_name }}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #93
* #92

----

* This workflow gets automatically triggered on any tag push if the tag starts with `v*`.
* This workflow builds and deploys the lib to PyPI with Twine.
* After a successful deployment to PyPI, the workflow calls another workflow to issue a GitHub release.