### PR TITLE
ci: add ability to retrieve current version

### DIFF
--- a/ci/version_retriever.py
+++ b/ci/version_retriever.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python3
+
+import importlib
+import subprocess
+import sys
+
+# Insert path to roadmapper package in system path
+git_repo_root = subprocess.Popen(['/bin/git', 'rev-parse', '--show-toplevel'], stdout=subprocess.PIPE) \
+    .communicate()[0] \
+    .rstrip() \
+    .decode('utf-8')
+sys.path.insert(1, git_repo_root)
+
+
+def get_current_version() -> str:
+    roadmapper_version_module = importlib.import_module("src.roadmapper.version")
+    current_version = getattr(roadmapper_version_module, "__version__")
+    return current_version
+
+
+if __name__ == "__main__":
+    print(get_current_version())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = ['Pillow>=10.0.0', 'python-dateutil>=2.8.2', 'drawsvg>=2.2.0']
 [tool.setuptools.packages.find]
 where = ["src"] # list of folders that contain the packages (["."] by default)
 exclude = [
+    "ci",
     "demo",
     "generate_gallery",
     "test_cases",


### PR DESCRIPTION
This script allows to retrieve the current source code version. This functionality will be used later on to bump the version automatically.