### PR TITLE
ci: add workflow to release on GitHub

### DIFF
--- a/.github/workflows/release-on-github.yaml
+++ b/.github/workflows/release-on-github.yaml
@@ -1,0 +1,30 @@
+name: Release on GitHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Create GitHub release of following tag
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      tag:
+        required: true
+        type: string
+
+jobs:
+  create-release:
+
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Create GitHub release
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/csgoh/roadmapper/releases \
+            -d '{"tag_name":"${{ inputs.tag }}","target_commitish":"main","draft":false,"prerelease":false,"generate_release_notes":true}'


### PR DESCRIPTION
* This workflow can be called either directly via the web UI or indirectly via another workflow.
* This worflow always requires a Git tag as an input to create a release of this exact tag.