### PR TITLE
ci: improve linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,7 @@ jobs:
       with:
         sparse-checkout: |
           .github
+          ci
           src
           pyproject.toml
           requirements.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ markers = [
 src = ["src"]
 
 # Ignore line length limitation
-ignore = ["E501"]
+lint.ignore = ["E501"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ markers = [
 
 [tool.ruff]
 
-# Lint only dir `src`
-src = ["src"]
+# Lint only mentioned dirs
+src = ["src", "ci"]
 
 # Ignore line length limitation
 lint.ignore = ["E501"]


### PR DESCRIPTION
According to the warning from Ruff `warning: The top-level linter settings are deprecated in favour of their counterparts in the 'lint' section.`, the linter settings should be adjusted. I moved our linter ignore settings from the top level to the level `linter`.

With the previous PRs, I introduced the new directory `ci/`. I added this directory to Rust's linter parsing.